### PR TITLE
arch/mips64el: remove -fprefetch-loop-arrays

### DIFF
--- a/arch/mips64el.sh
+++ b/arch/mips64el.sh
@@ -10,4 +10,4 @@
 
 # Note: Likely branch optimization is deprecated as of MIPS64.
 #       This optimization option is removed for MIPS64r6 target.
-CFLAGS_COMMON_ARCH=' -mabi=64 -march=mips64r2 -mtune=loongson3a -mno-branch-likely -fprefetch-loop-arrays '
+CFLAGS_COMMON_ARCH=' -mabi=64 -march=mips64r2 -mtune=loongson3a -mno-branch-likely '


### PR DESCRIPTION
- This is not a platform-specific flag, and should not be placed here.
- '-fprefetch-loop-arrays' is a hard optimization -- it might be opened on
  *some* softwares operating huge arrays, like databases, but not the
  whole system.