### PR TITLE
ab3_defcfg: add mips64el port

### DIFF
--- a/etc/autobuild/ab3_defcfg.sh
+++ b/etc/autobuild/ab3_defcfg.sh
@@ -128,6 +128,7 @@ abdetectarch(){
 		armv8l) echo arm64 ;;
 		ppc) echo powerpc ;;
 		ppc64) echo ppc64 ;;
+		mips64) echo mips64el ;;
 		*) uname -m ;;
 	esac
 }


### PR DESCRIPTION
We do MIPS64el (little-endian) port.