### PR TITLE
arch: draft for i586

### DIFF
--- a/arch/i586.sh
+++ b/arch/i586.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+##arch/i586.sh: Build definitions for i586.
+##@copyright GPL-2.0+
+CFLAGS_COMMON_ARCH='-march=i586 -mtune=bonnell -mhard-float '


### PR DESCRIPTION
Abstract and Rationale
---------------------------------

This port will target anything that is considered a i586 processor (with no requirement on MMX support). One of the first processors of this category will be the 1993 Intel Pentium "P5" processor running at 60/66MHz. Many iconic 32-bit x86 processors were born between 1993 and 2010, ending with the 45nm Intel Atom's of the "Bonnell" architecture. This long running processor micro-architecture, giving its basis to the x86_64 micro-architecture - the first and de-facto principal port of AOSC OS.

AOSC, our community, is home to a crew of vintage computing hobbists and enthusiasts - many of whom own x86-based devices that predated x86_64 (Intel 64 or AMD64) support, and had shown interest on AOSC OS running on these devices. As an digression, the `powerpc` and `ppc64` ports, targetting PowerPC-based Macintosh computers is a product of my personal interest (and is still a burden to port and maintain to this day, due to their quirky characteristics and lack of upstream support). However, it has also provided an option for Linux hobbists that own PowerMacs, iBooks, and PowerBooks, as support for these architectures from major Linux distributions are sun-setting.

The AOSC OS i586 port will serve a similar role to continue Linux usability on these older computers - with certain changes to functionality, which will likely also apply to the two PowerPC ports. More on this later.

Default Compiler Flags
---------------------------------

```
-march=i586 -mtune=bonnell -mhard-float
```

### Considerations

- As suggested by the objective of this port, the compiler flags will reflect support for even the most basic i586 processors.
- Default flag will enable as much optimisation for Bonnell-based Intel Atom devices as possible (`-mtune=bonnell`), as these represent one of the last consumer-grade 32-bit only x86 processors, which this port will support.
- `-mhard-float` specifies that 80387-based floating point instructions will be used, however, it is not yet clear if this flag will be necessary, given that `-march=i586` is already specified.
- This port will not be supported on: Intel 80386/80486 and compatibles (i386, i486); Winchip C6, Winchip 2 (winchip-c6, winchip2; as they are "dealt in same way as i486" with additonal instruction sets).¹

¹ GCC x86 Options: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html.

Challenges
----------------

AOSC OS, as it was designed, is taxing on older and storage-constraint devices, and older x86 devices (even the newest Atom-based netbooks and tablets) can be storage constrained. Feature support will have to be adjusted to make running AOSC OS on these devices not only possible, but *reasonable* and *practical*.

An initial thought to create an "AOSC OS Retro" sub-project is currently culminating - this will include the `i586`, `powerpc`, and `ppc64` ports. Not subject to discuss in this issue - but essentially, any port maintained under this sub-project will be paired-back on the feature front.