### PR TITLE
amd64_avx2: remove rdrnd

### DIFF
--- a/arch/amd64_avx2+.sh
+++ b/arch/amd64_avx2+.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 ##arch/amd64_avx2.sh: Build definitions for amd64 with AVX2 support.
-##                    Intel Haswell and AMD Zen or later processors.
+##                    Intel Haswell+, AMD bdver4+, VIA eden-x4+.
 ##@copyright GPL-2.0+
-CFLAGS_COMMON_ARCH=' -march=haswell '
+CFLAGS_COMMON_ARCH=' -march=haswell -mno-rdrnd '


### PR DESCRIPTION
Removing RDRND lets us support all the AVX2 CPUs in the setting. See https://sourceware.org/bugzilla/show_bug.cgi?id=23249#c12.

The question is... how important is RDRND for us anyways? Does GCC produce it without using intrinsics?