### PR TITLE
Feature: BUILDDEPONLY

### DIFF
--- a/etc/autobuild/ab3_defcfg.sh
+++ b/etc/autobuild/ab3_defcfg.sh
@@ -19,6 +19,7 @@ NOCARGOAUDIT=no			# Audit Cargo (Rust) dependencies?
 NONPMAUDIT=no			# Audit NPM dependencies?
 ABUSECMAKEBUILD=yes		# Use cmake build for cmake* ABTYPEs?
 ABSPLITDBG=yes			# Split out debug package containing symbols (-dbg)?
+BUILDDEPONLY=0			# Avoid installing runtime dependencies when building?
 
 # Strict Autotools option checking?
 AUTOTOOLS_STRICT=yes

--- a/etc/autobuild/ab3_defcfg.sh
+++ b/etc/autobuild/ab3_defcfg.sh
@@ -19,7 +19,7 @@ NOCARGOAUDIT=no			# Audit Cargo (Rust) dependencies?
 NONPMAUDIT=no			# Audit NPM dependencies?
 ABUSECMAKEBUILD=yes		# Use cmake build for cmake* ABTYPEs?
 ABSPLITDBG=yes			# Split out debug package containing symbols (-dbg)?
-BUILDDEPONLY=0			# Avoid installing runtime dependencies when building?
+ABBUILDDEPONLY=no		# Avoid installing runtime dependencies when building?
 
 # Strict Autotools option checking?
 AUTOTOOLS_STRICT=yes

--- a/proc/11-pm_deps.sh
+++ b/proc/11-pm_deps.sh
@@ -5,7 +5,7 @@ abrequire pm
 
 # FIXME: The flat stuff gets stupid with 'foo | bar' packs. Guess why.
 if bool $ABBUILDDEPONLY; then
-	if ! bool VER_NONE; then
+	if ! bool $VER_NONE; then
 		abdie "ABBUILDDEPONLY must be used with VER_NONE=1 (dependency version-agnostic). Aborting."
 	fi
 	FLATDEP="$(pm_deflat $BUILDDEP)"

--- a/proc/11-pm_deps.sh
+++ b/proc/11-pm_deps.sh
@@ -5,7 +5,11 @@ abrequire pm
 
 # FIXME: The flat stuff gets stupid with 'foo | bar' packs. Guess why.
 if bool $ABBUILDDEPONLY; then
-	FLATDEP="$(pm_deflat $BUILDDEP)"
+	if ! bool VER_NONE; then
+		aberr "ABBUILDDEPONLY must be used with VER_NONE=1 (dependency version-agnostic). Aborting."
+	else
+		FLATDEP="$(pm_deflat $BUILDDEP)"
+	fi
 else
 	FLATDEP="$(pm_deflat $PKGDEP $BUILDDEP $PKGPRDEP)"
 fi

--- a/proc/11-pm_deps.sh
+++ b/proc/11-pm_deps.sh
@@ -4,7 +4,7 @@
 abrequire pm
 
 # FIXME: The flat stuff gets stupid with 'foo | bar' packs. Guess why.
-if [[ $BULDDEPONLY == 1 ]]; then
+if bool $BUILDDEPONLY; then
 	FLATDEP="$(pm_deflat $BUILDDEP)"
 else
 	FLATDEP="$(pm_deflat $PKGDEP $BUILDDEP $PKGPRDEP)"

--- a/proc/11-pm_deps.sh
+++ b/proc/11-pm_deps.sh
@@ -4,7 +4,7 @@
 abrequire pm
 
 # FIXME: The flat stuff gets stupid with 'foo | bar' packs. Guess why.
-if bool $BUILDDEPONLY; then
+if bool $ABBUILDDEPONLY; then
 	FLATDEP="$(pm_deflat $BUILDDEP)"
 else
 	FLATDEP="$(pm_deflat $PKGDEP $BUILDDEP $PKGPRDEP)"

--- a/proc/11-pm_deps.sh
+++ b/proc/11-pm_deps.sh
@@ -4,7 +4,12 @@
 abrequire pm
 
 # FIXME: The flat stuff gets stupid with 'foo | bar' packs. Guess why.
-FLATDEP="$(pm_deflat $PKGDEP $BUILDDEP $PKGPRDEP)"
+if [[ $RMBDEP == 1 ]]; then
+	FLATDEP="$(pm_deflat $BUILDDEP)"
+else
+	FLATDEP="$(pm_deflat $PKGDEP $BUILDDEP $PKGPRDEP)"
+fi
+
 if ! pm_exists $FLATDEP; then
 	abinfo "Build or runtime dependencies not satisfied, now fetching needed packages."
 	pm_repoupdate

--- a/proc/11-pm_deps.sh
+++ b/proc/11-pm_deps.sh
@@ -6,10 +6,9 @@ abrequire pm
 # FIXME: The flat stuff gets stupid with 'foo | bar' packs. Guess why.
 if bool $ABBUILDDEPONLY; then
 	if ! bool VER_NONE; then
-		aberr "ABBUILDDEPONLY must be used with VER_NONE=1 (dependency version-agnostic). Aborting."
-	else
-		FLATDEP="$(pm_deflat $BUILDDEP)"
+		abdie "ABBUILDDEPONLY must be used with VER_NONE=1 (dependency version-agnostic). Aborting."
 	fi
+	FLATDEP="$(pm_deflat $BUILDDEP)"
 else
 	FLATDEP="$(pm_deflat $PKGDEP $BUILDDEP $PKGPRDEP)"
 fi

--- a/proc/11-pm_deps.sh
+++ b/proc/11-pm_deps.sh
@@ -4,7 +4,7 @@
 abrequire pm
 
 # FIXME: The flat stuff gets stupid with 'foo | bar' packs. Guess why.
-if [[ $RMBDEP == 1 ]]; then
+if [[ $BULDDEPONLY == 1 ]]; then
 	FLATDEP="$(pm_deflat $BUILDDEP)"
 else
 	FLATDEP="$(pm_deflat $PKGDEP $BUILDDEP $PKGPRDEP)"


### PR DESCRIPTION
Introducing new variable `BUILDDEPONLY`.

In `autobuild/defines`, if `BUILDDEPONLY` is set to `1`, the flattened list of dependencies will not include `PKGDEP`. Therefore, Autobuil3 will not install the runtime dependencies when building.