### PR TITLE
draft for loongarch64

### DIFF
--- a/arch/_common.sh
+++ b/arch/_common.sh
@@ -14,6 +14,7 @@ ARCH_TARGET['i386']=i686-aosc-linux-gnu
 ARCH_TARGET['i486']=i486-aosc-linux-gnu
 ARCH_TARGET['loongson2f']=mips64el-aosc-linux-gnuabi64
 ARCH_TARGET['loongson3']=mips64el-aosc-linux-gnuabi64
+ARCH_TARGET['loongarch64']=loongarch64-aosc-linux-gnu
 ARCH_TARGET['powerpc']=powerpc-aosc-linux-gnu
 ARCH_TARGET['ppc64']=powerpc64-aosc-linux-gnu
 ARCH_TARGET['ppc64el']=powerpc64le-aosc-linux-gnu

--- a/arch/loongarch64.sh
+++ b/arch/loongarch64.sh
@@ -2,4 +2,4 @@
 ##arch/loongarch64.sh: Build definitions for Loongson 3A/B 5000.
 ##@copyright GPL-2.0+
 
-CFLAGS_GCC_ARCH='-mabi=lp64 -march=loongarch64 -mtune=loongarch64 -mfix-loongson3-llsc'
+CFLAGS_GCC_ARCH='-mabi=lp64 -march=loongarch64 -mtune=loongarch64'

--- a/arch/loongarch64.sh
+++ b/arch/loongarch64.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+##arch/loongarch64.sh: Build definitions for Loongson 3A/B 5000.
+##@copyright GPL-2.0+
+
+CFLAGS_GCC_ARCH='-mabi=lp64 -march=loongarch64 -mtune=loongarch64 -mfix-loongson3-llsc'


### PR DESCRIPTION
autobuild3: initial adaptation for loongarch64 port; #119 
- tentative loongarch64 GCC compile flags and toolchain placeholder
- add arch/loongarch64.sh
- update arch/_common.sh to invoke toolchain placeholder
- delete meaningless mfix-loongson3-llsc flag for loongarch