### PR TITLE
build/15-rust.sh: inject lto before add new line

### DIFF
--- a/build/15-rust.sh
+++ b/build/15-rust.sh
@@ -22,7 +22,7 @@ build_rust_inject_lto() {
 	# parsing TOML in bash will be hard
 	grep 'profile.release' "$SRCDIR"/Cargo.toml > /dev/null 2>&1 \
 		&& abdie "$LTO_INJECT_FAIL_MSG"
-	echo -e "[profile.release]\nlto = true\n" >> "$SRCDIR"/Cargo.toml
+	echo -e "\n[profile.release]\nlto = true\n" >> "$SRCDIR"/Cargo.toml
 }
 
 build_rust_audit() {


### PR DESCRIPTION
Some projects do not end with a null line on Cargo.toml, this change will prevent the injection of LTO code to a non-new line