### PR TITLE
meta: introduce default GOFLAGS definition

### DIFF
--- a/arch/loongarch64.sh
+++ b/arch/loongarch64.sh
@@ -6,4 +6,4 @@ CFLAGS_GCC_ARCH='-mabi=lp64 -march=loongarch64 -mtune=loongarch64'
 
 # Position-independent executable buildmode is not available on loong64 architecture.
 # Removing for loongarch64 target.
-GOFLAGS=${GOFLGAS/-buildmode=pie/}
+GOFLAGS=${GOFLAGS/-buildmode=pie/}

--- a/arch/loongarch64.sh
+++ b/arch/loongarch64.sh
@@ -3,3 +3,7 @@
 ##@copyright GPL-2.0+
 
 CFLAGS_GCC_ARCH='-mabi=lp64 -march=loongarch64 -mtune=loongarch64'
+
+# Position-independent executable buildmode is not available on loong64 architecture.
+# Removing for loongarch64 target.
+GOFLAGS=${GOFLGAS/-buildmode=pie/}

--- a/arch/loongson2f.sh
+++ b/arch/loongson2f.sh
@@ -11,3 +11,7 @@ CFLAGS_GCC_ARCH='-mloongson-mmi -Wa,-mfix-loongson2f-nop '
 
 CFLAGS_GCC_OPTI_LTO="${CFLAGS_COMMON_OPTI_LTO} -flto-partition=none "
 LDFLAGS_GCC_OPTI_LTO="${LDFLAGS_COMMON_OPTI_LTO} -mxgot -flto-partition=none "
+
+# Position-independent executable buildmode is not available on any mips architecture.
+# Removing for loongson2f target.
+GOFLAGS=${GOFLGAS/-buildmode=pie/}

--- a/arch/loongson2f.sh
+++ b/arch/loongson2f.sh
@@ -14,4 +14,4 @@ LDFLAGS_GCC_OPTI_LTO="${LDFLAGS_COMMON_OPTI_LTO} -mxgot -flto-partition=none "
 
 # Position-independent executable buildmode is not available on any mips architecture.
 # Removing for loongson2f target.
-GOFLAGS=${GOFLGAS/-buildmode=pie/}
+GOFLAGS=${GOFLAGS/-buildmode=pie/}

--- a/arch/loongson3.sh
+++ b/arch/loongson3.sh
@@ -9,4 +9,4 @@ RUSTFLAGS_COMMON_OPTI_LTO="${RUSTFLAGS_COMMON_OPTI_LTO} -Clink-arg=-Wl,-build-id
 
 # Position-independent executable buildmode is not available on any mips architecture.
 # Removing for loongson3 target.
-GOFLAGS=${GOFLGAS/-buildmode=pie/}
+GOFLAGS=${GOFLAGS/-buildmode=pie/}

--- a/arch/loongson3.sh
+++ b/arch/loongson3.sh
@@ -6,3 +6,7 @@ CFLAGS_CLANG_ARCH='-mabi=64 -march=mips64r2 -mtune=mips64r2 '
 CFLAGS_GCC_OPTI_LTO="${CFLAGS_COMMON_OPTI_LTO} -flto-partition=none "
 LDFLAGS_GCC_OPTI_LTO="${LDFLAGS_COMMON_OPTI_LTO} -mxgot -flto-partition=none "
 RUSTFLAGS_COMMON_OPTI_LTO="${RUSTFLAGS_COMMON_OPTI_LTO} -Clink-arg=-Wl,-build-id=sha1 -Clink-arg=-Wl,-z,notext "
+
+# Position-independent executable buildmode is not available on any mips architecture.
+# Removing for loongson3 target.
+GOFLAGS=${GOFLGAS/-buildmode=pie/}

--- a/arch/powerpc.sh
+++ b/arch/powerpc.sh
@@ -11,4 +11,4 @@ CFLAGS_COMMON_ARCH=' -m32 -mcpu=G3 -mtune=G4 -mno-altivec -msecure-plt -mhard-fl
 
 # Position-independent executable buildmode is not available on PowerPC 32-bit architecture.
 # Removing for powerpc target.
-GOFLAGS=${GOFLGAS/-buildmode=pie/}
+GOFLAGS=${GOFLAGS/-buildmode=pie/}

--- a/arch/powerpc.sh
+++ b/arch/powerpc.sh
@@ -8,3 +8,7 @@ CFLAGS_COMMON_OPTI='-Os '
 CFLAGS_GCC_OPTI='-fira-loop-pressure -fira-hoist-pressure '
 
 CFLAGS_COMMON_ARCH=' -m32 -mcpu=G3 -mtune=G4 -mno-altivec -msecure-plt -mhard-float '
+
+# Position-independent executable buildmode is not available on PowerPC 32-bit architecture.
+# Removing for powerpc target.
+GOFLAGS=${GOFLGAS/-buildmode=pie/}

--- a/arch/ppc64.sh
+++ b/arch/ppc64.sh
@@ -15,4 +15,4 @@ RUSTFLAGS_COMMON_OPTI_LTO='-Clink-arg=-fuse-ld=bfd -Clink-arg=-Wl,-build-id=sha1
 
 # Position-independent executable buildmode is not available on PowerPC 64-bit 
 # (Big Endian) architecture. Removing for ppc64 target.
-GOFLAGS=${GOFLGAS/-buildmode=pie/}
+GOFLAGS=${GOFLAGS/-buildmode=pie/}

--- a/arch/ppc64.sh
+++ b/arch/ppc64.sh
@@ -12,3 +12,7 @@ LDFLAGS_GCC_OPTI_LTO="${LDFLAGS_COMMON_OPTI_LTO} -flto-partition=none "
 
 # LLD does not support POWER ABI v1.
 RUSTFLAGS_COMMON_OPTI_LTO='-Clink-arg=-fuse-ld=bfd -Clink-arg=-Wl,-build-id=sha1'
+
+# Position-independent executable buildmode is not available on PowerPC 64-bit 
+# (Big Endian) architecture. Removing for ppc64 target.
+GOFLAGS=${GOFLGAS/-buildmode=pie/}

--- a/build/15-gomod.sh
+++ b/build/15-gomod.sh
@@ -28,15 +28,9 @@ build_gomod_build(){
 	BUILD_READY
 	mkdir -pv "$PKGDIR/usr/bin/"
 	abinfo "Compiling Go module ..."
-	if [[ "${CROSS:-$ARCH}" != "loongson3" ]]; then
-		GOPATH="$SRCDIR/abgopath" \
-			go build -buildmode=pie ${GO_BUILD_AFTER} .. \
-			|| abdie "Failed to build Go module: $?."
-	else
-		GOPATH="$SRCDIR/abgopath" \
-			go build ${GO_BUILD_AFTER} .. \
-			|| abdie "Failed to build Go module: $?."
-	fi
+	GOPATH="$SRCDIR/abgopath" \
+		go build ${GO_BUILD_AFTER} .. \
+		|| abdie "Failed to build Go module: $?."
 	abinfo "Copying executable file(s) ..."
 	find "$SRCDIR" -type f -executable \
 		-exec cp -av '{}' "$PKGDIR/usr/bin/" ';' \

--- a/etc/autobuild/ab3_defcfg.sh
+++ b/etc/autobuild/ab3_defcfg.sh
@@ -145,7 +145,7 @@ RECONF=yes
 ABQA=yes
 ABINSTALL="dpkg"
 
-# Golang default build flags
+# Golang default build flags | Adapted from Arch Linux's Go package guildline.
 GOFLAGS+=" -mod=readonly" # Ensure module files are not updated during building process.
 GOFLAGS+=" -trimpath"     # Required for eproducible build.
 GOFLAGS+=" -modcacherw"   # Ensures that go modules creates a write-able path.

--- a/etc/autobuild/ab3_defcfg.sh
+++ b/etc/autobuild/ab3_defcfg.sh
@@ -145,6 +145,12 @@ RECONF=yes
 ABQA=yes
 ABINSTALL="dpkg"
 
+# Golang default build flags
+GOFLAGS+=" -mod=readonly" # Ensure module files are not updated during building process.
+GOFLAGS+=" -trimpath"     # Required for eproducible build.
+GOFLAGS+=" -modcacherw"   # Ensures that go modules creates a write-able path.
+GOFLAGS+=" -buildmode=pie"# Hardening binary.
+
 # Old, default.
 [[ -d "$AB"/etc/autobuild/defaults ]] && recsr "$AB"/etc/autobuild/defaults/*!(.dpkg*|dist)
 

--- a/etc/autobuild/ab3_defcfg.sh
+++ b/etc/autobuild/ab3_defcfg.sh
@@ -146,10 +146,10 @@ ABQA=yes
 ABINSTALL="dpkg"
 
 # Golang default build flags | Adapted from Arch Linux's Go package guildline.
-GOFLAGS+=" -mod=readonly" # Ensure module files are not updated during building process.
-GOFLAGS+=" -trimpath"     # Required for eproducible build.
-GOFLAGS+=" -modcacherw"   # Ensures that go modules creates a write-able path.
-GOFLAGS+=" -buildmode=pie"# Hardening binary.
+GOFLAGS+=" -mod=readonly"  # Ensure module files are not updated during building process.
+GOFLAGS+=" -trimpath"      # Required for eproducible build.
+GOFLAGS+=" -modcacherw"    # Ensures that go modules creates a write-able path.
+GOFLAGS+=" -buildmode=pie" # Hardening binary.
 
 # Old, default.
 [[ -d "$AB"/etc/autobuild/defaults ]] && recsr "$AB"/etc/autobuild/defaults/*!(.dpkg*|dist)


### PR DESCRIPTION
In recent aosc-os-abbs topic [Go-1.18-survey-20220401](https://github.com/AOSC-Dev/aosc-os-abbs/pull/3923) , it is found that similar GOFLAGS is defined repeatably, making build script harder to read. This pull request attempt to resolve aforementioned issue and may make further packaging for go-based project easilier.

File changes: 
- `etc/autobuild/ab3_defcfg.sh`: set default `GOFLAGS`
- `arch/loongson3.sh`: disable go's `-buildmode=pie`
- `build/15-gomod.sh`: remove redundant check and codepath for loongson3