### PR TITLE
`<build_type>_AFTER` declared as an array in defines

### DIFF
--- a/build/10-autotools.sh
+++ b/build/10-autotools.sh
@@ -63,15 +63,19 @@ build_autotools_build() {
 
 	BUILD_START
 	abinfo "Running configure ..."
+	local AUTOTOOLS_OPTION_CHECKING
 	if bool "$AUTOTOOLS_STRICT"; then
+		AUTOTOOLS_OPTION_CHECKING="--enable-option-checking=fatal"
+	fi
+	if abisarray AUTOTOOLS_AFTER; then
 		${configure:="$SRCDIR"/configure} \
-			$AUTOTOOLS_TARGET $AUTOTOOLS_DEF $AUTOTOOLS_AFTER \
-			--enable-option-checking=fatal \
+			$AUTOTOOLS_TARGET $AUTOTOOLS_DEF "${AUTOTOOLS_AFTER[@]}" \
+			$AUTOTOOLS_OPTION_CHECKING \
 			|| abdie "Failed to run configure: $?."
 	else
-		abwarn "Strict Autotools option checking disabled !!"
 		${configure:="$SRCDIR"/configure} \
 			$AUTOTOOLS_TARGET $AUTOTOOLS_DEF $AUTOTOOLS_AFTER \
+			$AUTOTOOLS_OPTION_CHECKING \
 			|| abdie "Failed to run configure: $?."
 	fi
 

--- a/build/11-cmakeninja.sh
+++ b/build/11-cmakeninja.sh
@@ -19,9 +19,14 @@ build_cmakeninja_build(){
 	fi
 	BUILD_START
 
-	abinfo "Running CMakeLists.txt to generate Ninja configuration ..."
-	cmake "$SRCDIR" $CMAKE_DEF $CMAKE_AFTER -GNinja \
-		|| abdie "Failed to run CMakeList.txt: $?."
+	abinfo "Running CMakeLists.txt to generate Ninja Configuration ..."
+	if abisarray CMAKE_AFTER; then
+		cmake "$SRCDIR" $CMAKE_DEF "${CMAKE_AFTER[@]}" -GNinja \
+			|| abdie "Failed to run CMakeLists.txt: $?."
+	else
+		cmake "$SRCDIR" $CMAKE_DEF $CMAKE_AFTER -GNinja \
+			|| abdie "Failed to run CMakeLists.txt: $?."
+	fi
 	BUILD_READY
 
 	if bool "$ABUSECMAKEBUILD"; then
@@ -37,7 +42,7 @@ build_cmakeninja_build(){
 		DESTDIR="$PKGDIR" \
 			ninja $ABMK $MAKE_AFTER install \
 			|| abdie "Failed to build and install binaries: $?."
-        fi
+	fi
 
 	if bool "$ABSHADOW"; then
 		cd "$SRCDIR" \

--- a/build/12-cmake.sh
+++ b/build/12-cmake.sh
@@ -19,8 +19,13 @@ build_cmake_build(){
 	BUILD_START
 
 	abinfo "Running CMakeLists.txt to generate Makefile ..."
-	cmake "$SRCDIR" $CMAKE_DEF $CMAKE_AFTER \
-		|| abdie "Failed to run CMakeLists.txt: $?."
+	if abisarray CMAKE_AFTER; then
+		cmake "$SRCDIR" $CMAKE_DEF "${CMAKE_AFTER[@]}" \
+			|| abdie "Failed to run CMakeLists.txt: $?."
+	else
+		cmake "$SRCDIR" $CMAKE_DEF $CMAKE_AFTER \
+			|| abdie "Failed to run CMakeLists.txt: $?."
+	fi
 	BUILD_READY
 
 	if bool "$ABUSECMAKEBUILD"; then

--- a/build/12-meson.sh
+++ b/build/12-meson.sh
@@ -11,9 +11,15 @@ build_meson_build() {
 	mkdir "$BLDDIR" \
 		|| abdie "Failed to create build directory: $?."
 	abinfo "Running Meson ..."
-	meson ${MESON_DEF} ${MESON_AFTER} \
-		"$SRCDIR" "$BLDDIR" \
-		|| abdie "Failed to run Meson ..."
+	if abisarray MESON_AFTER; then
+		meson ${MESON_DEF} "${MESON_AFTER[@]}" \
+			"$SRCDIR" "$BLDDIR" \
+			|| abdie "Failed to run Meson ..."
+	else
+		meson ${MESON_DEF} ${MESON_AFTER} \
+			"$SRCDIR" "$BLDDIR" \
+			|| abdie "Failed to run Meson ..."
+	fi
 	cd "$BLDDIR" \
 		|| abdie "Failed to enter build directory: $?."
 	abinfo "Building binaries ..."

--- a/lib/base.sh
+++ b/lib/base.sh
@@ -198,3 +198,16 @@ boolopt(){
 		return 0
 	fi
 }
+
+# <SOMETHING>_AFTER type checking
+# returns 0 if $1 points to an array
+abisarray() {
+	local VARIABLE_NAME="$1"
+	local VARIABLE_DECL=$( (declare -p $VARIABLE_NAME 2>/dev/null ) | head -1 | cut -f 2 -d ' ' )
+
+	if [[ "${VARIABLE_DECL}" == -*a* ]]; then
+		return 0
+	else
+		return 1
+	fi
+}


### PR DESCRIPTION
Currentlys AB3 couldn't handle parameter passing to cmake / autotools / meson for options that contain literal space characters due to `<build_type>_AFTER` being a single string. As a result bash cannot possibly distinguish a literal space apart from inter-field separators that splits the string into `char**`. AOSC maintainers usually resort to writing custom build scripts whenever these cases arises... which isn't great for consistency.

This PR adds support to use bash array for values of `CMAKE_AFTER`, `AUTOTOOLS_AFTER` and `MESON_AFTER`. Any options that should contain literal spaces can be specified as following:
```
CMAKE_AFTER=(
    "-DOPTION_NAME=This is a literal sentence"
    "-DQUOTED_OPTION=QuotedValue"
    -DUNQUOTED_OPTION=Value
)
```

Existing `<build_type>_AFTER` as a huge string is still supported.
