### PR TITLE
qa/post/permission.sh: add file type check for *.so.*

### DIFF
--- a/qa/post/permissions.sh
+++ b/qa/post/permissions.sh
@@ -7,7 +7,9 @@ if [ ! -z "$FILES" ]; then
 		tee -a "$SRCDIR"/abqaerr.log
 fi
 
-FILES="$(find "$PKGDIR/usr/lib" -type f -name '*.so.*' -not -executable -print 2>/dev/null)"
+FILES="$(find "$PKGDIR/usr/lib" -type f -name '*.so.*' -not -executable \
+	-exec bash -c '[[ "`file -bL {}`" == *shared\ object* ]] && exit 0' \; \
+	-print 2>/dev/null)"
 if [ ! -z "$FILES" ]; then
 	aberr "QA (E324): non-executable shared object(s) found in /usr/lib:\n\n${FILES}\n" | \
 		tee -a "$SRCDIR"/abqaerr.log


### PR DESCRIPTION
The PR will fix a problem that when running `qa/post/permission.sh`. An example is that in the post-build QA phase of building `ocaml-ctypes` 0.16.0, autobuild3 will mistakenly treat some `*.so.owner` ASCII text file as shared object and fail the test. 

Commit 93f7388a will add a check command to determine whether the file is an ELF shared object or something else. 

## Tests
The commit is tested via a dummy test package.

### `spec`
```
VER=1
DUMMYSRC=1
```

### `defines`
```
PKGNAME=testpkg
PKGDESC="Test package"
PKGSEC=admin
```

### `prepare`
```
mkdir -vp $PKGDIR/usr/lib

cp -v /usr/lib/libffi.so $PKGDIR/usr/lib/THIS_SHOULD_FAIL.so.1
cp -v /usr/lib/libffi.so $PKGDIR/usr/lib/THIS_SHOULD_FAIL_TOO.so.2
echo "Never gonna give you up~" > $PKGDIR/usr/lib/BUT_THIS_SHOULD_NOT_FAIL.so.owner

chmod -x $PKGDIR/usr/lib/THIS_SHOULD_FAIL*
```

### Image prove
![image](https://user-images.githubusercontent.com/22998116/184873539-becd6d61-17cf-4d3d-9e36-8d9b4d2bb148.png)

Signed-off-by: Camber Huang <camber@aosc.io>