### PR TITLE
arch: introduce mips64r6el support

### DIFF
--- a/arch/_common.sh
+++ b/arch/_common.sh
@@ -17,6 +17,7 @@ ARCH_TARGET['loongson2f']=mips64el-aosc-linux-gnuabi64
 ARCH_TARGET['loongson3']=mips64el-aosc-linux-gnuabi64
 ARCH_TARGET['loongarch64']=loongarch64-aosc-linux-gnu
 ARCH_TARGET['m68k']=m68k-aosc-linux-gnu
+ARCH_TARGET['mips64r6el']=mipsisa64r6el-aosc-linux-gnuabi64
 ARCH_TARGET['powerpc']=powerpc-aosc-linux-gnu
 ARCH_TARGET['ppc64']=powerpc64-aosc-linux-gnu
 ARCH_TARGET['ppc64el']=powerpc64le-aosc-linux-gnu

--- a/arch/mips64r6el.sh
+++ b/arch/mips64r6el.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 ##arch/mips64r6el.sh: Build definitions for mips64r6el.
 ##@copyright GPL-2.0+
-CFLAGS_COMMON_ARCH='-march=mips64r6 -mtune=mips64r6 '
+CFLAGS_COMMON_ARCH='-march=mips64r6 -mtune=mips64r6 -mcompact-branches=always '
 RUSTFLAGS_COMMON_ARCH='-Ctarget-cpu=mips64r6 '

--- a/arch/mips64r6el.sh
+++ b/arch/mips64r6el.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+##arch/mips64r6el.sh: Build definitions for mips64r6el.
+##@copyright GPL-2.0+
+CFLAGS_COMMON_ARCH='-march=mips64r6 -mtune=mips64r6 '
+RUSTFLAGS_COMMON_ARCH='-Ctarget-cpu=mips64r6 '


### PR DESCRIPTION
This is a change from the AOSC-CIP-Pilot project, which maintains AOSC OS' `mips64r6el` port, until it's deem ready for upstreaming to AOSC-Dev. This tooling change introduces `mips64r6el` architecture definitions.

- Triplet: `mips64r6el-aosc-linux-gnuabi64`
- Default C/C++ compiler flags: `-march=mips64r6 -mtune=mips64r6 -mcompact-branches=always`
- Default Rust target: `-Ctarget-cpu=mips64r6`