### PR TITLE
meta: introduce .stage2 suffix support

### DIFF
--- a/build/00-self.sh
+++ b/build/00-self.sh
@@ -9,8 +9,22 @@ build_self_probe(){
 
 build_self_build(){
 	BUILD_START
-	arch_loadfile_strict build \
-		|| abdie "Failed to run self-defined build script: $?."
+	if ! bool $ABSTAGE2; then
+		arch_loadfile_strict build || \
+			abdie "Failed to run self-defined build script: $?."
+	else
+		if arch_findfile build.stage2; then
+			abwarn "ABSTAGE2 returned true, loading stage2 build script ..."
+			arch_loadfile_strict build.stage2 || \
+				abdie "Failed to run self-defined stage2 build script: $?."
+		else
+			abwarn "ABSTAGE2 returned true, loading stage2 build script ..."
+			abwarn "Could not find self-defined stage2 build script, falling back to normal build script ..."
+			arch_loadfile_strict build || \
+				abdie "Failed to run self-defined build script: $?."
+		fi
+	fi
+
 	cd "$SRCDIR"
 }
 

--- a/etc/autobuild/ab3_defcfg.sh
+++ b/etc/autobuild/ab3_defcfg.sh
@@ -157,6 +157,13 @@ GOFLAGS+=" -buildmode=pie" # Hardening binary.
 . "$AB"/etc/autobuild/ab3cfg.sh
 [[ -d "$AB"/etc/autobuild/ab3cfg.d ]] && recsr "$AB"/etc/autobuild/ab3cfg.d/*!(.dpkg*|dist)
 
+if bool $ABSTAGE2; then
+	abwarn "Autobuild3 running in stage2 mode ..."
+	NOCARGOAUDIT=yes
+	NONPMAUDIT=yes
+	ABSPLITDBG=no
+fi
+
 abdetectarch() {
 	type dpkg >/dev/null 2>&1 && dpkg --print-architecture || ( echo "[!!!] Cannot find dpkg executable, exiting ..." && exit 1 )
 }

--- a/proc/10-core_defines.sh
+++ b/proc/10-core_defines.sh
@@ -20,8 +20,20 @@ abrequire arch
 BUILD=${ARCH_TARGET["$ABBUILD"]}
 HOST=${ARCH_TARGET["$ABHOST"]}
 
-
-_arch_trymore=1 arch_loadfiles defines || abdie "defines returned a non-zero value: $?." 
+if ! bool $ABSTAGE2; then
+	_arch_trymore=1 arch_loadfiles defines || \
+		abdie "Failed to source defines file: $?."
+else
+	abwarn "ABSTAGE2 returned true, loading stage2 defines ..."
+	if arch_findfile defines.stage2; then
+		_arch_trymore=1 arch_loadfiles defines.stage2 || \
+                        abdie "Failed to source stage2 defines file: $?."
+	else
+		abwarn "Unable to find stage2 defines, falling back to normal defines ..."
+		_arch_trymore=1 arch_loadfiles defines || \
+			abdie "Failed to source defines file: $?."
+	fi
+fi
 [[ ${ABHOST%%\/*} != $FAIL_ARCH ]] ||
 	abdie "This package cannot be built for $FAIL_ARCH, e.g. $ABHOST."
 

--- a/proc/40-patch.sh
+++ b/proc/40-patch.sh
@@ -3,9 +3,21 @@
 ##@copyright GPL-2.0+
 abrequire arch
 
-if [ ! -f "$SRCDIR"/.patch ]
-then
-	if arch_loadfile_strict patch; then
+if [ ! -f "$SRCDIR"/.patch ]; then
+	if [ -f "$SRCDIR"/autobuild/patch ]; then
+		arch_loadfile_strict patch
+		touch "$SRCDIR"/.patch
+	elif [ -f "$SRCDIR"/autobuild/patch ] && bool $ABSTAGE2; then
+		if arch_loadfile_strict patch.stage2; then
+			abwarn "ABSTAGE2 returned true, running stage2 patch script ..."
+			arch_loadfile_strict patch.stage2
+		elif arch_loadfile_strict patch; then
+			abwarn "ABSTAGE2 returned true, running stage2 patch script ..."
+			abwarn "Could not find self-defined stage patch script, failling back to main patch script ..."
+			arch_loadfile_strict patch
+		else
+			true
+		fi
 		touch "$SRCDIR"/.patch
 	elif [ -f "$SRCDIR"/autobuild/patches/series ]; then
 		ab_apply_patches \

--- a/proc/50-build_exec.sh
+++ b/proc/50-build_exec.sh
@@ -1,7 +1,21 @@
 #!/bin/bash
 ##proc/build_do: So we build it now
 ##@copyright GPL-2.0+
-arch_loadfile_strict prepare
+
+if ! bool $ABSTAGE2; then
+	arch_loadfile_strict prepare
+else
+	if arch_findfile prepare.stage2; then
+		abwarn "ABSTAGE2 returned true, running stage2 prepare script ..."
+		arch_loadfile_strict prepare.stage2
+	elif arch_findfile prepare; then
+		abwarn "ABSTAGE2 returned true, running stage2 prepare script ..."
+		abwarn "Could not find stage2 prepare script, falling back to normal prepare script ..."
+		arch_loadfile_strict prepare
+	else
+		true
+	fi
+fi
 
 cd "$SRCDIR"
 
@@ -32,7 +46,20 @@ cd "$SRCDIR" || abdie "Unable to cd $SRCDIR: $?."
 
 [ -d "$PKGDIR" ] || abdie "50-build: Suspecting build failure due to missing PKGDIR."
 
-arch_loadfile_strict beyond
+if ! bool $ABSTAGE2; then
+	arch_loadfile_strict beyond
+else
+	if arch_findfile beyond.stage2; then
+		abwarn "ABSTAGE2 returned true, running stage2 beyond script ..."
+		arch_loadfile_strict beyond.stage2
+	elif arch_findfile beyond; then
+		abwarn "ABSTAGE2 returned true, running stage2 beyond script ..."
+		abwarn "Could not find stage2 beyond script, falling back to normal beyond script ..."
+		arch_loadfile_strict beyond
+	else
+		true
+	fi
+fi
 
 if [ -d "$(arch_findfile overrides)" ] ; then
 	abinfo "Deploying files in overrides ..."


### PR DESCRIPTION
This pull request introduces support for Autobuild3 to read from `.stage2` (minimal/bootstrapping) recipes. Enable this mode by adding `ABSTAGE2=1` to `ab3cfg.sh`.

ACBS and Ciel has each introduced support to adapt to this change.