### PR TITLE
lib/arch, lib/base: Enforce type checking during copy-assigning (#140)

### DIFF
--- a/lib/arch.sh
+++ b/lib/arch.sh
@@ -39,8 +39,8 @@ arch_loadvar(){
 	local name_archvar=${1}__${ABHOST^^}
 	local name_commonvar=${1}
 	if abisdefined $name_archvar; then
+		abdbg "Setting ${name_commonvar} from arch-specific variable $name_archvar"
 		abcopyvar $name_archvar $name_commonvar
-		abdbg "Setting ${name_commonvar} to arch-specific variable $name_archvar"
 	else
 		# Need to try to match group one by one
 		for _GROUP in ${ABHOST_GROUP}; do
@@ -55,7 +55,7 @@ arch_loadvar(){
 					abdie "Ambiguous architecture group variable detected! Refuse to proceed."
 					break
 				fi
-				abdbg "Setting $name_commonvar to group-specific variable $name_groupvar"
+				abdbg "Setting $name_commonvar from group-specific variable $name_groupvar"
 				abcopyvar $name_groupvar $name_commonvar
 				_assignedGroup=${_GROUP}
 			fi

--- a/lib/base.sh
+++ b/lib/base.sh
@@ -238,7 +238,7 @@ abcopyvar() {
 		else
 			aberr "$src is a single string, but $dst is an array."
 		fi
-		abdie "Cannot copy variables of different type!"
+		abdie "Refusing to copy variables of different type!"
 	fi
 
 	# Create references for content r/w


### PR DESCRIPTION
autobuild3 allows maintainers to specify one or more `VARIABLE__AMD64` (by archtecture) and `VARIABLE__RETRO` (by arch group). These variables will override `VARIABLE` if the current building arch matches the more specific flags.

Earlier in #130 support is added to allow variables (e.g. `CMAKE_AFTER`) to be defined as a bash indexed array. However, at this point overriding `CMAKE_AFTER`-as-an-array with a literal `CMAKE_AFTER__ARM64` or the other way around is messed up and let's say undefined behavior.

This PR adds a short hand `abcopyvar` that enforces identical types for source and destination variables when copy-assigning, and causes build to fail if types don't match, i.e. when VAR_AMD64 is an array but VAR is a string literal, or when VAR_AMD64 is a string literal but VAR is an array. Existing copy-assignment should be changed to use this function instead.