### PR TITLE
mips64r6el: apply Rust workarounds

### DIFF
--- a/arch/mips64r6el.sh
+++ b/arch/mips64r6el.sh
@@ -2,4 +2,4 @@
 ##arch/mips64r6el.sh: Build definitions for mips64r6el.
 ##@copyright GPL-2.0+
 CFLAGS_COMMON_ARCH='-march=mips64r6 -mtune=mips64r6 -mcompact-branches=always -mmsa '
-RUSTFLAGS_COMMON_ARCH='-Ctarget-cpu=mips64r6 '
+RUSTFLAGS_COMMON_ARCH='-Ctarget-cpu=mips64r6 -Cdebuginfo=0 --cfg=rustix_use_libc '

--- a/arch/mips64r6el.sh
+++ b/arch/mips64r6el.sh
@@ -2,4 +2,13 @@
 ##arch/mips64r6el.sh: Build definitions for mips64r6el.
 ##@copyright GPL-2.0+
 CFLAGS_COMMON_ARCH='-march=mips64r6 -mtune=mips64r6 -mcompact-branches=always -mmsa '
+
+# FIXME: -Cdebuginfo=0 enables rustc to build programs on mips64r6el,
+# overriding all project configuration and build profile settings.
+# Generating debuginfo crashes LLVM (as of 15.0.7).
+#
+# FIXME: --cfg=rustix_use_libc works around an issue where a crate named
+# rustix contains MIPS64 R2 assembly, without being able to distinguish between
+# R2 and R6 assemblies. Enabling this options instructs rustix to use the libc
+# backend instead.
 RUSTFLAGS_COMMON_ARCH='-Ctarget-cpu=mips64r6 -Cdebuginfo=0 --cfg=rustix_use_libc '


### PR DESCRIPTION
This PR does the following two things:
- It sets `-Cdebuginfo=0` for rustc compiler. It enables rustc to build programs on mips64r6el, overriding all project configuration and build profile settings. Debug information just makes LLVM crash, not only on rustc, also Clang.
- It sets `--cfg=rustix_use_libc` for rustc compiler. This is on purpose because a crate named `rustix` has mips64r2 assembly written in it, but rustix itself can not distinguish between mips64r2 and mips64r6. Enabling config `rustix_use_libc` tells rustix to use underlying libc backend instead.