### PR TITLE
mancompress: use pb=0 special sauce

### DIFF
--- a/filter/infocompress.sh
+++ b/filter/infocompress.sh
@@ -19,7 +19,7 @@ filter_infocompress() {
 		done
 
 		abinfo "Compressing Texinfo page ${__infocomp_todo[@]} ..."
-		xz -6e -- "${__infocomp_todo[@]}"
+		xz --lzma2=preset=6e,pb=0 -- "${__infocomp_todo[@]}"
 	fi
 
 	unset __infocomp_todo __infocomp_lnk

--- a/filter/mancompress.sh
+++ b/filter/mancompress.sh
@@ -19,7 +19,7 @@ filter_mancompress() {
 		done
 
 		abinfo "Compressing man page ${__mancomp_todo[@]} ..."
-		xz -6e -- "${__mancomp_todo[@]}"
+		xz --lzma2=preset=6e,pb=0 -- "${__mancomp_todo[@]}"
 	fi
 
 	unset __mancomp_todo __mancomp_lnk


### PR DESCRIPTION
xz(1) suggests using pb=0 for general English text. https://bugs.gentoo.org/169260#c19 shows that doing so cuts 1/3 from the compressed size, which is big. 

But do note that man-db search is awful slow for non-gz compression because of all the pipework involved. gz used to be slow to, until man-db started doing zlib decompress. See uhhh... somewhere around https://lore.kernel.org/linux-man/44768e26-ed92-0562-2318-68fec781126b@gmail.com/T/#m25978be2ce8245c67773911dbeb33140604e6d77.

Oh and xz without pb=0 doesn't provide much more compression than gzip -9, which is very normal given the tiny files. Maybe we should just go for gz.