### PR TITLE
Testing: better handling for NOTEST=yes

### DIFF
--- a/etc/autobuild/ab3_defcfg.sh
+++ b/etc/autobuild/ab3_defcfg.sh
@@ -65,11 +65,11 @@ AB_LD_BFD=0
 # Default testing flags
 ABTESTS=""
 ABTEST_AUTO_DETECT=yes
-ABTEST_ABORT_BUILD=yes
+ABTEST_ABORT_BUILD=no
 ABTEST_TESTEXEC=plain
 ABTEST_AUTO_DETECT_STAGE=post-build
 ABTESTTYPE_rust_STAGE=post-build
-NOTEST=no
+NOTEST=yes
 
 ##OS Directory Tree
 # Built-in variables for AOSC OS directory tree.

--- a/pm/dpkg/pack
+++ b/pm/dpkg/pack
@@ -48,9 +48,17 @@ dpkgctrl(){
 	if dpkg -l autobuild3 >/dev/null 2>&1; then
 		echo "X-AOSC-Autobuild3-Version: $(dpkg-query -f '${Version}' -W autobuild3)"
 	fi
-	if ! bool $NOTEST; then
+	if bool $NOTEST; then
+		echo "X-AOSC-Autobuild3-Testing: disabled"
+	else
+		if [[ -n $ABTESTS ]]; then
+			# Redundant `echo' trims extra whitespaces
+			echo "X-AOSC-Autobuild3-Testing: $(echo $ABTESTS)"
+		else
+			echo "X-AOSC-Autobuild3-Testing: none"
+		fi
 		if [[ -n $ABTEST_FAILED ]]; then
-			echo "X-AOSC-Testing-Failed: $ABTEST_FAILED"
+			echo "X-AOSC-Autobuild3-Testing-Failed: $(echo $ABTEST_FAILED)"
 		fi
 		if [[ -e $ABTEST_RESULT_OUTPUT ]]; then
 			cat $ABTEST_RESULT_OUTPUT

--- a/proc/10-tests_scan.sh
+++ b/proc/10-tests_scan.sh
@@ -5,6 +5,7 @@
 if bool $NOTEST; then
     ABTESTS=""
     TESTDEP="" # Empty TESTDEPS by explicitly override it
+    ABTEST_AUTO_DETECT=no
 else
     abrequire tests
     export ABTEST_RESULT_OUTPUT="$SRCDIR/abtestoutput.txt"

--- a/proc/31-tests_probe.sh
+++ b/proc/31-tests_probe.sh
@@ -8,4 +8,6 @@ if bool $ABTEST_AUTO_DETECT; then
     fi
 fi
 
-abinfo "Currently enabled tests are: $ABTESTS"
+if ! bool $NOTEST; then
+    abinfo "Currently enabled tests are: $ABTESTS"
+fi


### PR DESCRIPTION
- No more junk logs
- Set NOTEST by default
- More information in the dpkg control file
- Remove unnecessary testing probe for NOTEST builds